### PR TITLE
Implemented pipe end option

### DIFF
--- a/lib/StreamCache.js
+++ b/lib/StreamCache.js
@@ -24,7 +24,7 @@ StreamCache.prototype.write = function(buffer) {
 
 StreamCache.prototype.pipe = function(dest, options) {
   if (options) {
-    throw Error('StreamCache#pipe: options are not supported yet.');
+    warn('StreamCache#pipe: options are not supported yet.');
   }
 
   this._buffers.forEach(function(buffer) {

--- a/lib/StreamCache.js
+++ b/lib/StreamCache.js
@@ -11,6 +11,7 @@ function StreamCache() {
 
   this._buffers = [];
   this._dests   = [];
+  this._ends    = [];
   this._ended   = false;
 }
 
@@ -23,20 +24,17 @@ StreamCache.prototype.write = function(buffer) {
 };
 
 StreamCache.prototype.pipe = function(dest, options) {
-  if (options) {
-    console.warn('StreamCache#pipe: options are not supported yet.');
-  }
-
   this._buffers.forEach(function(buffer) {
     dest.write(buffer);
   });
 
-  if (this._ended) {
+  if (this._ended && options.end) {
     dest.end();
     return dest;
   }
 
   this._dests.push(dest);
+  this._ends.push(options && options.end || true);
 
   return dest;
 };
@@ -48,9 +46,11 @@ StreamCache.prototype.getLength = function() {
 };
 
 StreamCache.prototype.end = function() {
-  this._dests.forEach(function(dest) {
-    dest.end();
-  });
+  for (var i = 0; i < this._dests.length; i++) {
+    if (this._ends[i]) {
+      this._dests[i].end();
+    }
+  }
 
   this._ended = true;
   this._dests = [];

--- a/lib/StreamCache.js
+++ b/lib/StreamCache.js
@@ -24,7 +24,7 @@ StreamCache.prototype.write = function(buffer) {
 
 StreamCache.prototype.pipe = function(dest, options) {
   if (options) {
-    warn('StreamCache#pipe: options are not supported yet.');
+    console.warn('StreamCache#pipe: options are not supported yet.');
   }
 
   this._buffers.forEach(function(buffer) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Felix Geisendörfer <felix@debuggable.com> (http://debuggable.com/)",
   "name": "stream-cache",
   "description": "A simple way to cache and replay readable streams.",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "homepage": "https://github.com/felixge/node-stream-cache",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   "engines": {
     "node": ">= 0.9.4"
   },
+  "scripts": {
+    "test": "node test/all.js"
+  },
   "dependencies": {},
   "devDependencies": {},
   "optionalDependencies": {}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Felix Geisendörfer <felix@debuggable.com> (http://debuggable.com/)",
   "name": "stream-cache",
   "description": "A simple way to cache and replay readable streams.",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "homepage": "https://github.com/felixge/node-stream-cache",
   "repository": {
     "type": "git",
@@ -10,7 +10,7 @@
   },
   "main": "./index",
   "engines": {
-    "node": "*"
+    "node": ">= 0.9.4"
   },
   "dependencies": {},
   "devDependencies": {},

--- a/test/all.js
+++ b/test/all.js
@@ -1,1 +1,2 @@
+require('./test-end-option');
 require('./test-with-child-processes');

--- a/test/all.js
+++ b/test/all.js
@@ -1,0 +1,1 @@
+require('./test-with-child-processes');

--- a/test/test-end-option.js
+++ b/test/test-end-option.js
@@ -1,0 +1,38 @@
+var StreamCache = require('..');
+var PassThrough = require('stream').PassThrough;
+var assert      = require('assert');
+
+// Does the end option allow writables to end.
+(function() {
+  var cache    = new StreamCache();
+  var source   = new PassThrough();
+  var superSourceEnd = source.end;
+  source.end = function() {
+    superSourceEnd();
+    assert.ok(true);
+  };
+
+  source.pipe(cache, {end: true});
+  source.write('hello');
+
+  cache.end();
+})();
+
+// Does the end option prevent writables from ending.
+(function() {
+  var cache    = new StreamCache();
+  var source   = new PassThrough();
+  var superSourceEnd = source.end;
+  source.end = function() {
+    superSourceEnd();
+    assert.ok(false);
+  };
+
+  source.pipe(cache, {end: false});
+  source.write('hello');
+
+  cache.end();
+  source.end = superSourceEnd;
+  source.end();
+  assert.ok(true);
+})();


### PR DESCRIPTION
The `end` option should work now. I added a test case for it and a new test script to the package. I was not able to get the first test (`test-with-child-processes`) working.